### PR TITLE
feat(structures): Role, Member, Collection + Server/Channel methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ export { Message } from './structures/Message';
 export { Server } from './structures/Server';
 export { Channel } from './structures/Channel';
 export { User } from './structures/User';
+export { Role } from './structures/Role';
+export { Member } from './structures/Member';
+export { Collection } from './structures/Collection';
 
 // REST
 export { REST } from './rest';
@@ -31,7 +34,7 @@ export {
 export { GatewayState } from './gateway';
 
 // Shared raw types
-export type { RawUser, RawServer, RawChannel, RawMessage } from './types';
+export type { RawUser, RawServer, RawChannel, RawMessage, RawRole, RawMember } from './types';
 
 // Version
 export const version = '0.1.0';

--- a/src/rest/REST.ts
+++ b/src/rest/REST.ts
@@ -290,6 +290,11 @@ export class REST {
     return this.request<void>('DELETE', `/servers/${serverId}`);
   }
 
+  public async leaveServer(serverId: string): Promise<void> {
+    this.validateSnowflake(serverId, 'serverId');
+    return this.request<void>('DELETE', `/servers/${serverId}/members/@me`);
+  }
+
   // Channels
   public async getChannel(channelId: string): Promise<ChannelData> {
     this.validateSnowflake(channelId, 'channelId');

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -1,5 +1,6 @@
 import type { ClientRef } from '../client/ClientRef';
 import type { RawChannel } from '../types';
+import { Message } from './Message';
 
 export class Channel {
   readonly id: string;
@@ -11,7 +12,10 @@ export class Channel {
   readonly parentId: string | null;
   readonly createdAt: Date;
 
-  constructor(data: RawChannel, _client: ClientRef) {
+  readonly #client: ClientRef;
+
+  constructor(data: RawChannel, client: ClientRef) {
+    this.#client   = client;
     this.id        = data.id;
     this.serverId  = data.server_id;
     this.name      = data.name;
@@ -20,5 +24,27 @@ export class Channel {
     this.position  = data.position;
     this.parentId  = data.parent_id ?? null;
     this.createdAt = new Date(data.created_at);
+  }
+
+  send(content: string): Promise<Message> {
+    return this.#client.rest
+      .createMessage(this.id, { content })
+      .then((raw) => new Message(raw, this.#client));
+  }
+
+  edit(data: { name?: string; topic?: string; position?: number }): Promise<Channel> {
+    return this.#client.rest
+      .updateChannel(this.id, data)
+      .then((raw) => new Channel(raw, this.#client));
+  }
+
+  delete(): Promise<void> {
+    return this.#client.rest.deleteChannel(this.id);
+  }
+
+  fetchMessages(options?: { limit?: number; before?: string; after?: string }): Promise<Message[]> {
+    return this.#client.rest
+      .listMessages(this.id, options)
+      .then((msgs) => msgs.map((raw) => new Message(raw, this.#client)));
   }
 }

--- a/src/structures/Collection.ts
+++ b/src/structures/Collection.ts
@@ -1,0 +1,48 @@
+/**
+ * A Map subclass with extra utility methods — mirrors the discord.js Collection API
+ * so bots ported from discord.js feel at home.
+ */
+export class Collection<K, V> extends Map<K, V> {
+  filter(fn: (value: V, key: K) => boolean): Collection<K, V> {
+    const result = new Collection<K, V>();
+    for (const [k, v] of this) {
+      if (fn(v, k)) result.set(k, v);
+    }
+    return result;
+  }
+
+  find(fn: (value: V, key: K) => boolean): V | undefined {
+    for (const [k, v] of this) {
+      if (fn(v, k)) return v;
+    }
+    return undefined;
+  }
+
+  map<T>(fn: (value: V, key: K) => T): T[] {
+    const result: T[] = [];
+    for (const [k, v] of this) {
+      result.push(fn(v, k));
+    }
+    return result;
+  }
+
+  first(): V | undefined {
+    return this.values().next().value;
+  }
+
+  last(): V | undefined {
+    let last: V | undefined;
+    for (const v of this.values()) last = v;
+    return last;
+  }
+
+  random(): V | undefined {
+    const arr = [...this.values()];
+    if (!arr.length) return undefined;
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+
+  toJSON(): V[] {
+    return [...this.values()];
+  }
+}

--- a/src/structures/Member.ts
+++ b/src/structures/Member.ts
@@ -1,0 +1,24 @@
+import type { ClientRef } from '../client/ClientRef';
+import type { RawMember } from '../types';
+import { User } from './User';
+
+export class Member {
+  readonly user: User;
+  readonly serverId: string;
+  readonly nickname: string | null;
+  readonly roles: string[];
+  readonly joinedAt: Date;
+
+  constructor(data: RawMember, client: ClientRef) {
+    this.user     = new User(data.user, client);
+    this.serverId = data.server_id;
+    this.nickname = data.nickname;
+    this.roles    = data.roles;
+    this.joinedAt = new Date(data.joined_at);
+  }
+
+  /** Display name — nickname if set, otherwise the underlying username */
+  get displayName(): string {
+    return this.nickname ?? this.user.username;
+  }
+}

--- a/src/structures/Role.ts
+++ b/src/structures/Role.ts
@@ -1,0 +1,26 @@
+import type { ClientRef } from '../client/ClientRef';
+import type { RawRole } from '../types';
+
+export class Role {
+  readonly id: string;
+  readonly serverId: string;
+  readonly name: string;
+  readonly permissions: number;
+  readonly position: number;
+  readonly color: number;
+  readonly hoist: boolean;
+  readonly mentionable: boolean;
+  readonly createdAt: Date;
+
+  constructor(data: RawRole, _client: ClientRef) {
+    this.id          = data.id;
+    this.serverId    = data.server_id;
+    this.name        = data.name;
+    this.permissions = data.permissions;
+    this.position    = data.position;
+    this.color       = data.color;
+    this.hoist       = data.hoist;
+    this.mentionable = data.mentionable;
+    this.createdAt   = new Date(data.created_at);
+  }
+}

--- a/src/structures/Server.ts
+++ b/src/structures/Server.ts
@@ -1,5 +1,6 @@
 import type { ClientRef } from '../client/ClientRef';
 import type { RawServer } from '../types';
+import { Channel } from './Channel';
 
 export class Server {
   readonly id: string;
@@ -10,7 +11,10 @@ export class Server {
   readonly memberCount: number;
   readonly createdAt: Date;
 
-  constructor(data: RawServer, _client: ClientRef) {
+  readonly #client: ClientRef;
+
+  constructor(data: RawServer, client: ClientRef) {
+    this.#client     = client;
     this.id          = data.id;
     this.name        = data.name;
     this.ownerId     = data.owner_id;
@@ -18,5 +22,25 @@ export class Server {
     this.description = data.description ?? null;
     this.memberCount = data.member_count;
     this.createdAt   = new Date(data.created_at);
+  }
+
+  edit(data: { name?: string; description?: string }): Promise<Server> {
+    return this.#client.rest
+      .updateServer(this.id, data)
+      .then((raw) => new Server(raw, this.#client));
+  }
+
+  delete(): Promise<void> {
+    return this.#client.rest.deleteServer(this.id);
+  }
+
+  leave(): Promise<void> {
+    return this.#client.rest.leaveServer(this.id);
+  }
+
+  createChannel(data: { name: string; type?: number; topic?: string; position?: number }): Promise<Channel> {
+    return this.#client.rest
+      .createChannel(this.id, { type: 0, ...data })
+      .then((raw) => new Channel(raw, this.#client));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,3 +39,23 @@ export interface RawMessage {
   attachments?: unknown[];
   embeds?: unknown[];
 }
+
+export interface RawRole {
+  id: string;
+  server_id: string;
+  name: string;
+  permissions: number;
+  position: number;
+  color: number;
+  hoist: boolean;
+  mentionable: boolean;
+  created_at: string;
+}
+
+export interface RawMember {
+  user: RawUser;
+  server_id: string;
+  nickname: string | null;
+  roles: string[];
+  joined_at: string;
+}


### PR DESCRIPTION
Closes #4

Adds Role and Member structures, Collection class, and action methods to Server and Channel.

- **Role** — maps wire data to camelCase (id, serverId, name, permissions, color, hoist, mentionable)
- **Member** — wraps user as a User instance, exposes nickname/roles/joinedAt, `displayName` falls back to username when no nickname set
- **Collection** — extends Map with filter/find/map/first/last/random/toJSON, same shape as discord.js so ported bots feel at home
- **Server** — edit(), delete(), leave(), createChannel()
- **Channel** — send(), edit(), delete(), fetchMessages()
- **REST** — leaveServer() added for `DELETE /servers/:id/members/@me`