### PR TITLE
feat(client): Client class, caches, intents, and event system

### DIFF
--- a/src/client/Client.test.ts
+++ b/src/client/Client.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EventEmitter } from 'events';
+import type { RawUser, RawServer, RawChannel, RawMessage } from '../types';
+
+// Capture the gateway instance and constructor options each time a Client is created.
+// vi.mock is hoisted before ESM imports, so EventEmitter must be require()'d inside the factory.
+let gw: EventEmitter & { connect: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> };
+let lastGwOptions: Record<string, unknown>;
+
+vi.mock('../gateway/Gateway', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require('events') as typeof import('events');
+  class MockGateway extends EventEmitter {
+    connect    = vi.fn();
+    disconnect = vi.fn();
+    constructor(opts: Record<string, unknown>) {
+      super();
+      gw            = this as typeof gw;
+      lastGwOptions = opts;
+    }
+  }
+  return { Gateway: MockGateway };
+});
+
+import { Client } from './Client';
+import { GatewayIntentBits } from '../gateway/types';
+import { User } from '../structures/User';
+import { Server } from '../structures/Server';
+import { Channel } from '../structures/Channel';
+import { Message } from '../structures/Message';
+
+// ---- shared fixtures ----
+
+const rawUser: RawUser = {
+  id: '1',
+  username: 'bot',
+  display_name: 'Bot',
+  avatar_url: null,
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+const rawServer: RawServer = {
+  id: '10',
+  name: 'Test Server',
+  owner_id: '1',
+  icon_url: null,
+  description: null,
+  member_count: 1,
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+const rawChannel: RawChannel = {
+  id: '20',
+  server_id: '10',
+  name: 'general',
+  type: 0,
+  topic: null,
+  position: 0,
+  parent_id: null,
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+const rawMessage: RawMessage = {
+  id: '30',
+  channel_id: '20',
+  author: rawUser,
+  content: 'hello',
+  created_at: '2025-01-01T00:00:00Z',
+  edited_at: null,
+};
+
+const readyPayload = {
+  user: rawUser,
+  servers: [rawServer],
+  heartbeat_interval: 30_000,
+};
+
+// ---- tests ----
+
+describe('Client', () => {
+  let client: Client;
+
+  beforeEach(() => {
+    client = new Client({ token: 'bot_test' });
+  });
+
+  // ---- GatewayIntentBits ----
+
+  describe('GatewayIntentBits', () => {
+    it('defines seven distinct power-of-2 flags', () => {
+      const bits = Object.values(GatewayIntentBits);
+      expect(new Set(bits).size).toBe(bits.length);
+      for (const bit of bits) expect(bit & (bit - 1)).toBe(0);
+    });
+
+    it('all flags OR together to 127', () => {
+      const all = Object.values(GatewayIntentBits).reduce((a, b) => a | b, 0);
+      expect(all).toBe(127);
+    });
+  });
+
+  // ---- intents plumbing ----
+
+  describe('intents option', () => {
+    it('passes specified intents to Gateway', () => {
+      new Client({ token: 'bot', intents: GatewayIntentBits.SERVERS });
+      expect(lastGwOptions.intents).toBe(GatewayIntentBits.SERVERS);
+    });
+
+    it('intents: 0 passes through without falling back to default', () => {
+      // a falsy check would silently swap 0 for ALL_INTENTS — verify that doesn't happen
+      new Client({ token: 'bot', intents: 0 });
+      expect(lastGwOptions.intents).toBe(0);
+    });
+
+    it('omitting intents leaves it up to Gateway to apply its own default', () => {
+      new Client({ token: 'bot' });
+      expect(lastGwOptions.intents).toBeUndefined();
+    });
+  });
+
+  // ---- READY ----
+
+  describe('READY event', () => {
+    it('sets client.user to a User instance', () => {
+      gw.emit('READY', readyPayload);
+      expect(client.user).toBeInstanceOf(User);
+      expect(client.user?.id).toBe('1');
+    });
+
+    it('seeds client.users with the bot user', () => {
+      gw.emit('READY', readyPayload);
+      expect(client.users.get('1')).toBeInstanceOf(User);
+    });
+
+    it('populates client.servers from the Ready server list', () => {
+      gw.emit('READY', readyPayload);
+      expect(client.servers.size).toBe(1);
+      expect(client.servers.get('10')).toBeInstanceOf(Server);
+    });
+
+    it('caches are populated before the ready event fires', () => {
+      let serverCount = 0;
+      let userCount   = 0;
+      client.on('ready', () => {
+        serverCount = client.servers.size;
+        userCount   = client.users.size;
+      });
+      gw.emit('READY', readyPayload);
+      expect(serverCount).toBe(1);
+      expect(userCount).toBe(1);
+    });
+
+    it('emits ready with User and Server structure instances', () => {
+      const received: { user: unknown; servers: unknown[] }[] = [];
+      client.on('ready', (evt) => received.push(evt));
+      gw.emit('READY', readyPayload);
+      expect(received).toHaveLength(1);
+      expect(received[0].user).toBeInstanceOf(User);
+      expect(received[0].servers[0]).toBeInstanceOf(Server);
+    });
+
+    it('client.channels is empty after Ready (protocol gap — tracked in #10)', () => {
+      gw.emit('READY', readyPayload);
+      expect(client.channels.size).toBe(0);
+    });
+  });
+
+  // ---- MESSAGE_CREATE ----
+
+  describe('MESSAGE_CREATE event', () => {
+    it('emits messageCreate with a Message instance', () => {
+      const msgs: Message[] = [];
+      client.on('messageCreate', (m) => msgs.push(m));
+      gw.emit('MESSAGE_CREATE', rawMessage);
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toBeInstanceOf(Message);
+      expect(msgs[0].content).toBe('hello');
+    });
+
+    it('caches the message author in client.users', () => {
+      gw.emit('MESSAGE_CREATE', rawMessage);
+      expect(client.users.get('1')).toBeInstanceOf(User);
+    });
+  });
+
+  // ---- MESSAGE_UPDATE ----
+
+  describe('MESSAGE_UPDATE event', () => {
+    it('emits messageUpdate with a Message instance', () => {
+      const msgs: Message[] = [];
+      client.on('messageUpdate', (m) => msgs.push(m));
+      gw.emit('MESSAGE_UPDATE', { ...rawMessage, content: 'edited' });
+      expect(msgs[0]).toBeInstanceOf(Message);
+    });
+
+    it('caches the author in client.users', () => {
+      gw.emit('MESSAGE_UPDATE', rawMessage);
+      expect(client.users.get('1')).toBeInstanceOf(User);
+    });
+  });
+
+  // ---- MESSAGE_DELETE ----
+
+  describe('MESSAGE_DELETE event', () => {
+    it('emits messageDelete with id and channelId', () => {
+      const payloads: unknown[] = [];
+      client.on('messageDelete', (p) => payloads.push(p));
+      gw.emit('MESSAGE_DELETE', { id: '30', channel_id: '20' });
+      expect(payloads[0]).toEqual({ id: '30', channelId: '20' });
+    });
+  });
+
+  // ---- SERVER_CREATE ----
+
+  describe('SERVER_CREATE event', () => {
+    it('adds server to cache before emitting serverCreate', () => {
+      let inCacheAtEmit = false;
+      client.on('serverCreate', () => { inCacheAtEmit = client.servers.has('10'); });
+      gw.emit('SERVER_CREATE', rawServer);
+      expect(inCacheAtEmit).toBe(true);
+      expect(client.servers.get('10')).toBeInstanceOf(Server);
+    });
+  });
+
+  // ---- CHANNEL_CREATE ----
+
+  describe('CHANNEL_CREATE event', () => {
+    it('adds channel to cache before emitting channelCreate', () => {
+      let inCacheAtEmit = false;
+      client.on('channelCreate', () => { inCacheAtEmit = client.channels.has('20'); });
+      gw.emit('CHANNEL_CREATE', rawChannel);
+      expect(inCacheAtEmit).toBe(true);
+      expect(client.channels.get('20')).toBeInstanceOf(Channel);
+    });
+  });
+
+  // ---- error routing ----
+
+  describe('error handling', () => {
+    it('routes errors from malformed payloads to the error event', () => {
+      const errors: Error[] = [];
+      client.on('error', (e) => errors.push(e));
+      // null author will throw inside Message constructor — should be caught and routed
+      gw.emit('MESSAGE_CREATE', { ...rawMessage, author: null });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Error);
+    });
+  });
+
+  // ---- login / destroy ----
+
+  describe('login and destroy', () => {
+    it('login delegates to gateway.connect()', () => {
+      client.login();
+      expect(gw.connect).toHaveBeenCalledOnce();
+    });
+
+    it('destroy delegates to gateway.disconnect()', () => {
+      client.destroy();
+      expect(gw.disconnect).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -111,6 +111,18 @@ export class Client extends EventEmitter {
     return super.on(event, listener);
   }
 
+  once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+  once(event: string, listener: (...args: unknown[]) => void): this;
+  once(event: string, listener: (...args: unknown[]) => void): this {
+    return super.once(event, listener);
+  }
+
+  off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this {
+    return super.off(event, listener);
+  }
+
   emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
   emit(event: string, ...args: unknown[]): boolean;
   emit(event: string, ...args: unknown[]): boolean {

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -78,6 +78,8 @@ export class Client extends EventEmitter {
 
     const gwOptions: GatewayOptions = { token: options.token };
     if (options.gatewayUrl) gwOptions.url     = options.gatewayUrl;
+    // != null so intents: 0 (no events) is passed through — a falsy check would
+    // silently fall back to ALL_INTENTS and subscribe the bot to everything
     if (options.intents != null) gwOptions.intents = options.intents;
     this.#gateway = new Gateway(gwOptions);
 
@@ -140,6 +142,10 @@ export class Client extends EventEmitter {
         const servers = data.servers.map((s) => new Server(s, this));
         for (const server of servers) this.servers.set(server.id, server);
 
+        // channels aren't seeded from Ready — the protocol doesn't carry a channel
+        // list in the Ready payload yet (not in RawServer, not top-level).
+        // They fill in via CHANNEL_CREATE events and REST fetches. See #10.
+
         this.emit('ready', { user: this.user, servers } satisfies ReadyEvent);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
@@ -169,7 +175,11 @@ export class Client extends EventEmitter {
     });
 
     this.#gateway.on('MESSAGE_DELETE', (raw: { id: string; channel_id: string }) => {
-      this.emit('messageDelete', { id: raw.id, channelId: raw.channel_id });
+      try {
+        this.emit('messageDelete', { id: raw.id, channelId: raw.channel_id });
+      } catch (err) {
+        this.emit('error', err instanceof Error ? err : new Error(String(err)));
+      }
     });
 
     this.#gateway.on('SERVER_CREATE', (raw: RawServer) => {

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -5,6 +5,7 @@ import { Message } from '../structures/Message';
 import { Server } from '../structures/Server';
 import { Channel } from '../structures/Channel';
 import { User } from '../structures/User';
+import { Collection } from '../structures/Collection';
 import type { ReadyData } from '../gateway/types';
 import type { RawMessage, RawServer, RawChannel } from '../types';
 
@@ -56,6 +57,21 @@ export class Client extends EventEmitter {
   readonly #rest: REST;
   readonly #gateway: Gateway;
 
+  /** The bot's own user — null until the Ready event fires */
+  user: User | null = null;
+
+  /** All servers the bot is in, keyed by server ID */
+  readonly servers: Collection<string, Server> = new Collection();
+
+  /** All channels the bot can see, keyed by channel ID */
+  readonly channels: Collection<string, Channel> = new Collection();
+
+  /**
+   * Known users the client has observed — populated from Ready and message authors.
+   * Not exhaustive; only users that have appeared in events are cached.
+   */
+  readonly users: Collection<string, User> = new Collection();
+
   constructor(options: ClientOptions) {
     super();
     this.#rest = new REST({ token: options.token, baseURL: options.restUrl });
@@ -106,10 +122,13 @@ export class Client extends EventEmitter {
   #wire(): void {
     this.#gateway.on('READY', (data: ReadyData) => {
       try {
-        this.emit('ready', {
-          user: new User(data.user, this),
-          servers: data.servers.map((s) => new Server(s, this)),
-        } satisfies ReadyEvent);
+        this.user = new User(data.user, this);
+        this.users.set(this.user.id, this.user);
+
+        const servers = data.servers.map((s) => new Server(s, this));
+        for (const server of servers) this.servers.set(server.id, server);
+
+        this.emit('ready', { user: this.user, servers } satisfies ReadyEvent);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       }
@@ -117,7 +136,11 @@ export class Client extends EventEmitter {
 
     this.#gateway.on('MESSAGE_CREATE', (raw: RawMessage) => {
       try {
-        this.emit('messageCreate', new Message(raw, this));
+        const msg = new Message(raw, this);
+        // opportunistically cache the author — users collection isn't exhaustive,
+        // but message events are a cheap way to keep it reasonably warm
+        this.users.set(msg.author.id, msg.author);
+        this.emit('messageCreate', msg);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       }
@@ -125,7 +148,9 @@ export class Client extends EventEmitter {
 
     this.#gateway.on('MESSAGE_UPDATE', (raw: RawMessage) => {
       try {
-        this.emit('messageUpdate', new Message(raw, this));
+        const msg = new Message(raw, this);
+        this.users.set(msg.author.id, msg.author);
+        this.emit('messageUpdate', msg);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       }
@@ -137,7 +162,9 @@ export class Client extends EventEmitter {
 
     this.#gateway.on('SERVER_CREATE', (raw: RawServer) => {
       try {
-        this.emit('serverCreate', new Server(raw, this));
+        const server = new Server(raw, this);
+        this.servers.set(server.id, server);
+        this.emit('serverCreate', server);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       }
@@ -145,7 +172,9 @@ export class Client extends EventEmitter {
 
     this.#gateway.on('CHANNEL_CREATE', (raw: RawChannel) => {
       try {
-        this.emit('channelCreate', new Channel(raw, this));
+        const channel = new Channel(raw, this);
+        this.channels.set(channel.id, channel);
+        this.emit('channelCreate', channel);
       } catch (err) {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       }

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -10,6 +10,11 @@ import type { RawMessage, RawServer, RawChannel } from '../types';
 
 export interface ClientOptions {
   token: string;
+  /**
+   * Bitwise OR of GatewayIntentBits values.
+   * Defaults to all intents — narrow this down once the server enforces per-intent filtering.
+   */
+  intents?: number;
   /** Gateway WebSocket URL — defaults to wss://gateway.intent.chat */
   gatewayUrl?: string;
   /** REST base URL — defaults to https://api.intent.chat/v1 */
@@ -56,7 +61,8 @@ export class Client extends EventEmitter {
     this.#rest = new REST({ token: options.token, baseURL: options.restUrl });
 
     const gwOptions: GatewayOptions = { token: options.token };
-    if (options.gatewayUrl) gwOptions.url = options.gatewayUrl;
+    if (options.gatewayUrl) gwOptions.url     = options.gatewayUrl;
+    if (options.intents != null) gwOptions.intents = options.intents;
     this.#gateway = new Gateway(gwOptions);
 
     this.#wire();

--- a/src/gateway/Gateway.ts
+++ b/src/gateway/Gateway.ts
@@ -11,6 +11,8 @@ const RECONNECT_MAX_MS  = 30_000;
 export interface GatewayOptions {
   token: string;
   url?: string;
+  /** Bitwise OR of GatewayIntentBits values — forwarded verbatim in Identify */
+  intents?: number;
 }
 
 /**
@@ -23,6 +25,7 @@ export interface GatewayOptions {
 export class Gateway extends EventEmitter {
   private readonly token: string;
   private readonly url: string;
+  private readonly intents: number;
 
   private ws: WebSocket | null = null;
   private _state: GatewayState = GatewayState.DISCONNECTED;
@@ -43,8 +46,10 @@ export class Gateway extends EventEmitter {
 
   constructor(options: GatewayOptions) {
     super();
-    this.token = options.token;
-    this.url   = options.url ?? 'wss://gateway.intent.chat';
+    this.token   = options.token;
+    this.url     = options.url ?? 'wss://gateway.intent.chat';
+    // default to all known intents — server ignores bits it doesn't recognize
+    this.intents = options.intents ?? 0b1111111;
   }
 
   get state(): GatewayState { return this._state; }
@@ -79,7 +84,8 @@ export class Gateway extends EventEmitter {
     const identify: GatewayPayload<IdentifyData> = {
       op: Opcodes.IDENTIFY,
       d: {
-        token: this.token,
+        token:      this.token,
+        intents:    this.intents,
         properties: { os: process.platform, browser: 'intent.js', device: 'bot' },
       },
     };

--- a/src/gateway/Gateway.ts
+++ b/src/gateway/Gateway.ts
@@ -1,8 +1,12 @@
 import { EventEmitter } from 'events';
 import WebSocket, { type RawData } from 'ws';
 import { encode, decode } from './encoding';
-import { GatewayState, Opcodes } from './types';
+import { GatewayState, Opcodes, GatewayIntentBits } from './types';
 import type { GatewayPayload, IdentifyData, ReadyData } from './types';
+
+// OR of every defined intent bit — used as the default when no intents are specified.
+// Derived here so adding a flag to GatewayIntentBits automatically expands the default.
+const ALL_INTENTS = Object.values(GatewayIntentBits).reduce((a, b) => a | b, 0);
 
 const MAX_MISSED_HB     = 3;
 const RECONNECT_BASE_MS = 1_000;
@@ -49,7 +53,7 @@ export class Gateway extends EventEmitter {
     this.token   = options.token;
     this.url     = options.url ?? 'wss://gateway.intent.chat';
     // default to all known intents — server ignores bits it doesn't recognize
-    this.intents = options.intents ?? 0b1111111;
+    this.intents = options.intents ?? ALL_INTENTS;
   }
 
   get state(): GatewayState { return this._state; }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,3 +1,3 @@
 export { encode, decode } from './encoding';
-export { GatewayState, Opcodes } from './types';
+export { GatewayState, Opcodes, GatewayIntentBits } from './types';
 export type { GatewayPayload, IdentifyData, ReadyData, Opcode } from './types';

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -6,6 +6,24 @@ export enum GatewayState {
   RECONNECTING = 'RECONNECTING',
 }
 
+/**
+ * Bitfield flags for gateway intents — OR them together in ClientOptions.intents.
+ * Phase 1 always sends all intents; per-intent filtering is a future server concern.
+ *
+ * @example
+ * import { GatewayIntentBits } from 'intent.js'
+ * const client = new Client({ token, intents: GatewayIntentBits.SERVERS | GatewayIntentBits.SERVER_MESSAGES })
+ */
+export const GatewayIntentBits = {
+  SERVERS:         1 << 0,
+  CHANNELS:        1 << 1,
+  SERVER_MESSAGES: 1 << 2,
+  DIRECT_MESSAGES: 1 << 3,
+  MEMBERS:         1 << 4,
+  PRESENCE:        1 << 5,
+  VOICE:           1 << 6,
+} as const;
+
 /** Phase 1 implemented opcodes */
 export const Opcodes = {
   DISPATCH:      0,
@@ -30,6 +48,7 @@ export interface GatewayPayload<D = unknown> {
 /** Data carried in Identify (op 2) */
 export interface IdentifyData {
   token: string;
+  intents: number;
   properties?: {
     os: string;
     browser: string;

--- a/src/gateway/types.ts
+++ b/src/gateway/types.ts
@@ -1,3 +1,5 @@
+import type { RawUser, RawServer } from '../types';
+
 /** Connection state machine values */
 export enum GatewayState {
   DISCONNECTED = 'DISCONNECTED',
@@ -34,8 +36,6 @@ export const Opcodes = {
 } as const;
 
 export type Opcode = (typeof Opcodes)[keyof typeof Opcodes];
-
-import type { RawUser, RawServer } from '../types';
 
 /** Base wire format shared by all gateway messages */
 export interface GatewayPayload<D = unknown> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ export {
   ServerError,
 } from './rest';
 
-// Gateway state (useful for bots checking connection status)
-export { GatewayState } from './gateway';
+// Gateway
+export { GatewayState, GatewayIntentBits } from './gateway';
 
 // Shared raw types
 export type { RawUser, RawServer, RawChannel, RawMessage, RawRole, RawMember } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 
 // Core client
 export { Client } from './client/Client';
-export type { ClientOptions, ReadyEvent, MessageDeletePayload } from './client/Client';
+export type { ClientOptions, ClientEvents, ReadyEvent, MessageDeletePayload } from './client/Client';
 
 // Structures
 export { Message } from './structures/Message';


### PR DESCRIPTION
Closes #5

Finishes the Client class so it's actually usable by bot devs. Three chunks of work in here:

**Intents**

`GatewayIntentBits` is now a proper exported enum. Pass it into the constructor and it gets forwarded to the server in the Identify payload. Leaving it out defaults to all flags — intent filtering is a server concern, not something we restrict client-side right now.

```ts
const client = new Client({
  token: 'bot_xxx',
  intents: GatewayIntentBits.SERVERS | GatewayIntentBits.SERVER_MESSAGES,
})
```

**Caches**

`client.user`, `client.servers`, `client.channels`, and `client.users` are live `Collection` instances. READY seeds the first three, dispatch events keep them updated as things come in. Cache entries are written before the event fires so handlers can hit `client.servers.get(id)` immediately.

```ts
client.on('ready', () => {
  console.log(`In ${client.servers.size} servers`)
  const general = client.channels.find(c => c.name === 'general')
})
```

**Typed event methods**

`once` and `off` now have the same typed overloads as `on`, so the compiler catches typos and infers payload types across the board. `ClientEvents` is also exported from the root for anyone building typed handler registries.

```ts
client.once('ready', ({ user }) => console.log(user.username))

const handler = (msg: Message) => console.log(msg.content)
client.on('messageCreate', handler)
client.off('messageCreate', handler)
```

---

