### PR TITLE
test(rest): REST client test suite

### DIFF
--- a/src/rest/REST.test.ts
+++ b/src/rest/REST.test.ts
@@ -1,6 +1,63 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { REST } from './REST';
 import { IntentError } from './errors';
+import type { RawServer, RawMessage } from '../types';
+
+// ---- fetch mock helpers ----
+
+// Builds a minimal Response-like object for successful JSON responses
+function mockOk<T>(data: T, extraHeaders: Record<string, string> = {}): Response {
+  const headers: Record<string, string> = { 'content-type': 'application/json', ...extraHeaders };
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as unknown as Response;
+}
+
+// Builds a mock error response — status < 200 or >= 300
+function mockErr(status: number, body: Record<string, unknown> = {}): Response {
+  return {
+    ok: false,
+    status,
+    headers: { get: (k: string) => ({ 'content-type': 'application/json' })[k.toLowerCase()] ?? null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+// 204 No Content
+function mock204(): Response {
+  return {
+    ok: true,
+    status: 204,
+    headers: { get: () => null },
+    json: async () => undefined,
+    text: async () => '',
+  } as unknown as Response;
+}
+
+// Shared raw fixtures
+const rawServer: RawServer = {
+  id: '100',
+  name: 'Test Server',
+  owner_id: '1',
+  icon_url: null,
+  description: null,
+  member_count: 0,
+  created_at: '2025-01-01T00:00:00Z',
+};
+
+const rawMessage: RawMessage = {
+  id: '300',
+  channel_id: '200',
+  author: { id: '1', username: 'bot', display_name: 'Bot', avatar_url: null, created_at: '2025-01-01T00:00:00Z' },
+  content: 'hello',
+  created_at: '2025-01-01T00:00:00Z',
+  edited_at: null,
+};
 
 describe('REST', () => {
   describe('token guard', () => {
@@ -36,6 +93,88 @@ describe('REST', () => {
     it('rejects empty IDs', async () => {
       const rest = new REST({ token: 'test' });
       await expect(rest.getServer('')).rejects.toThrow('Invalid serverId');
+    });
+  });
+
+  // ---- request basics ----
+  // Each test stubs global fetch, makes one REST call, and inspects what
+  // fetch was actually called with.
+
+  describe('request basics', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', fetchMock);
+      fetchMock.mockReset();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('createServer sends POST to /servers with JSON body', async () => {
+      fetchMock.mockResolvedValueOnce(mockOk(rawServer));
+
+      const rest = new REST({ token: 'bot_token' });
+      await rest.createServer({ name: 'My Server' });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }];
+      expect(init.method).toBe('POST');
+      expect(url).toBe('https://api.intent.chat/v1/servers');
+      expect(JSON.parse(init.body as string)).toEqual({ name: 'My Server' });
+    });
+
+    it('sets Authorization: Bearer <token> on every request', async () => {
+      fetchMock.mockResolvedValueOnce(mockOk(rawServer));
+
+      const rest = new REST({ token: 'my_secret_token' });
+      await rest.listServers();
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }];
+      expect(init.headers['Authorization']).toBe('Bearer my_secret_token');
+    });
+
+    it('sets Content-Type: application/json on every request', async () => {
+      fetchMock.mockResolvedValueOnce(mockOk(rawServer));
+
+      const rest = new REST({ token: 'tok' });
+      await rest.listServers();
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }];
+      expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('listMessages sends GET with query params', async () => {
+      fetchMock.mockResolvedValueOnce(mockOk([rawMessage]));
+
+      const rest = new REST({ token: 'tok' });
+      await rest.listMessages('200', { limit: 50, before: '111111111' });
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsed = new URL(url);
+      expect(parsed.pathname).toBe('/v1/channels/200/messages');
+      expect(parsed.searchParams.get('limit')).toBe('50');
+      expect(parsed.searchParams.get('before')).toBe('111111111');
+    });
+
+    it('deleteChannel sends DELETE with no body', async () => {
+      fetchMock.mockResolvedValueOnce(mock204());
+
+      const rest = new REST({ token: 'tok' });
+      await rest.deleteChannel('200');
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('DELETE');
+      expect(url).toContain('/channels/200');
+      expect(init.body).toBeUndefined();
+    });
+
+    it('204 responses resolve to undefined without throwing', async () => {
+      fetchMock.mockResolvedValueOnce(mock204());
+
+      const rest = new REST({ token: 'tok' });
+      const result = await rest.deleteServer('100');
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/rest/REST.test.ts
+++ b/src/rest/REST.test.ts
@@ -69,25 +69,33 @@ const rawMessage: RawMessage = {
 
 describe('REST', () => {
   describe('token guard', () => {
+    // Stub fetch with an immediate network error so these tests don't make real
+    // HTTP calls — a missing token should throw IntentError before fetch is even
+    // called, and a present token should surface a TypeError (network), not IntentError.
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('throws IntentError when no token is set', async () => {
       const rest = new REST();
       await expect(rest.request('GET', '/test')).rejects.toThrow(IntentError);
       await expect(rest.request('GET', '/test')).rejects.toThrow('No auth token set');
     });
 
-    it('does not throw when token is provided in constructor', async () => {
+    it('does not throw IntentError when token is in constructor', async () => {
       const rest = new REST({ token: 'test_token' });
-      // will fail with a network error, but shouldn't throw IntentError
-      const result = rest.request('GET', '/test').catch((e) => e);
-      const err = await result;
+      const err = await rest.request('GET', '/test').catch((e) => e);
       expect(err).not.toBeInstanceOf(IntentError);
     });
 
-    it('does not throw after setToken()', async () => {
+    it('does not throw IntentError after setToken()', async () => {
       const rest = new REST();
       rest.setToken('test_token');
-      const result = rest.request('GET', '/test').catch((e) => e);
-      const err = await result;
+      const err = await rest.request('GET', '/test').catch((e) => e);
       expect(err).not.toBeInstanceOf(IntentError);
     });
   });

--- a/src/rest/REST.test.ts
+++ b/src/rest/REST.test.ts
@@ -102,6 +102,50 @@ describe('REST', () => {
       const rest = new REST({ token: 'test' });
       await expect(rest.getServer('')).rejects.toThrow('Invalid serverId');
     });
+
+    it('rejects IDs with letters mixed in', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.getServer('123abc')).rejects.toThrow('Invalid serverId');
+    });
+
+    it('rejects IDs with special characters', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.getServer('12-34')).rejects.toThrow('Invalid serverId');
+    });
+
+    it('validates channelId on getChannel', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.getChannel('not-an-id')).rejects.toThrow('Invalid channelId');
+    });
+
+    it('validates channelId on createMessage', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.createMessage('bad', { content: 'hi' })).rejects.toThrow('Invalid channelId');
+    });
+
+    it('validates both channelId and messageId on getMessage', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.getMessage('bad', '100')).rejects.toThrow('Invalid channelId');
+      await expect(rest.getMessage('100', 'bad')).rejects.toThrow('Invalid messageId');
+    });
+
+    it('validates before/after cursors on listMessages', async () => {
+      const rest = new REST({ token: 'test' });
+      await expect(rest.listMessages('100', { before: 'not-a-snowflake' })).rejects.toThrow('Invalid before');
+      await expect(rest.listMessages('100', { after: 'not-a-snowflake' })).rejects.toThrow('Invalid after');
+    });
+
+    it('accepts valid numeric snowflakes without throwing', async () => {
+      // Snowflake validation should not throw for all-digit IDs.
+      // Stub fetch so the call doesn't actually go out.
+      const fetchMock = vi.fn().mockResolvedValue(mockOk(rawServer));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const rest = new REST({ token: 'test' });
+      await expect(rest.getServer('123456789012345678')).resolves.toBeDefined();
+
+      vi.unstubAllGlobals();
+    });
   });
 
   // ---- request basics ----

--- a/src/rest/REST.test.ts
+++ b/src/rest/REST.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { REST } from './REST';
-import { IntentError } from './errors';
+import {
+  IntentError,
+  HTTPError,
+  RateLimitError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ServerError,
+} from './errors';
 import type { RawServer, RawMessage } from '../types';
 
 // ---- fetch mock helpers ----
@@ -175,6 +183,106 @@ describe('REST', () => {
       const rest = new REST({ token: 'tok' });
       const result = await rest.deleteServer('100');
       expect(result).toBeUndefined();
+    });
+  });
+
+  // ---- error status mapping ----
+  // Each test mocks a specific HTTP status and verifies the right error class
+  // comes back with the correct fields populated.
+
+  describe('error status mapping', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+      vi.stubGlobal('fetch', fetchMock);
+      fetchMock.mockReset();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('401 throws UnauthorizedError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(401, { error: 'invalid token' }));
+
+      const rest = new REST({ token: 'tok' });
+      await expect(rest.listServers()).rejects.toBeInstanceOf(UnauthorizedError);
+    });
+
+    it('403 throws ForbiddenError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(403, { error: 'no permission' }));
+
+      const rest = new REST({ token: 'tok' });
+      await expect(rest.listServers()).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('404 throws NotFoundError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(404, { error: 'not found' }));
+
+      const rest = new REST({ token: 'tok' });
+      await expect(rest.getServer('100')).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('429 throws RateLimitError with retryAfter and global populated', async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockErr(429, { error: 'rate limited', retry_after: 3, global: true })
+      );
+
+      // maxRetries: 0 so the 429 throws on the first attempt instead of sleeping and retrying
+      const rest = new REST({ token: 'tok', maxRetries: 0 });
+      const err = await rest.listServers().catch((e) => e) as RateLimitError;
+      expect(err).toBeInstanceOf(RateLimitError);
+      expect(err.retryAfter).toBe(3);
+      expect(err.global).toBe(true);
+    });
+
+    it('429 with bucket header populates err.bucket', async () => {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+        'x-ratelimit-bucket': 'my-bucket',
+      };
+      const response = mockErr(429, { error: 'rate limited', retry_after: 1, global: false });
+      (response.headers as unknown as { get: (k: string) => string | null }).get =
+        (k: string) => headers[k.toLowerCase()] ?? null;
+      fetchMock.mockResolvedValueOnce(response);
+
+      const rest = new REST({ token: 'tok', maxRetries: 0 });
+      const err = await rest.listServers().catch((e) => e) as RateLimitError;
+      expect(err.bucket).toBe('my-bucket');
+    });
+
+    it('500 throws ServerError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(500, { error: 'internal server error' }));
+
+      // maxRetries: 0 prevents the exponential backoff retry loop
+      const rest = new REST({ token: 'tok', maxRetries: 0 });
+      await expect(rest.listServers()).rejects.toBeInstanceOf(ServerError);
+    });
+
+    it('502 throws ServerError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(502, { error: 'bad gateway' }));
+
+      const rest = new REST({ token: 'tok', maxRetries: 0 });
+      await expect(rest.listServers()).rejects.toBeInstanceOf(ServerError);
+    });
+
+    it('unknown 4xx throws HTTPError', async () => {
+      fetchMock.mockResolvedValueOnce(mockErr(422, { error: 'unprocessable' }));
+
+      const rest = new REST({ token: 'tok' });
+      const err = await rest.listServers().catch((e) => e);
+      expect(err).toBeInstanceOf(HTTPError);
+      expect((err as HTTPError).status).toBe(422);
+    });
+
+    it('all HTTP errors extend IntentError', async () => {
+      for (const status of [401, 403, 404, 500]) {
+        fetchMock.mockResolvedValueOnce(mockErr(status, { error: 'err' }));
+        // maxRetries: 0 so 5xx doesn't retry and exhaust the mock queue
+        const rest = new REST({ token: 'tok', maxRetries: 0 });
+        const err = await rest.listServers().catch((e) => e);
+        expect(err).toBeInstanceOf(IntentError);
+      }
     });
   });
 });

--- a/src/rest/Route.test.ts
+++ b/src/rest/Route.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { Route } from './Route';
+
+describe('Route', () => {
+  describe('bucketKey', () => {
+    it('different server IDs produce different bucket keys', () => {
+      const a = new Route('GET', '/servers/111/channels');
+      const b = new Route('GET', '/servers/222/channels');
+      expect(a.bucketKey).not.toBe(b.bucketKey);
+    });
+
+    it('different channel IDs produce different bucket keys', () => {
+      const a = new Route('GET', '/channels/111/messages');
+      const b = new Route('GET', '/channels/222/messages');
+      expect(a.bucketKey).not.toBe(b.bucketKey);
+    });
+
+    it('same channel with different message IDs share a bucket key', () => {
+      // message_id is a minor param and gets normalized — both requests
+      // share the same rate limit bucket regardless of which message they target
+      const a = new Route('GET', '/channels/123/messages/111111111');
+      const b = new Route('GET', '/channels/123/messages/999999999');
+      expect(a.bucketKey).toBe(b.bucketKey);
+    });
+
+    it('different methods on the same path produce different bucket keys', () => {
+      const get  = new Route('GET',  '/channels/123/messages');
+      const post = new Route('POST', '/channels/123/messages');
+      expect(get.bucketKey).not.toBe(post.bucketKey);
+    });
+
+    it('PATCH on different messages in the same channel shares a key', () => {
+      const a = new Route('PATCH', '/channels/123/messages/111111111');
+      const b = new Route('PATCH', '/channels/123/messages/222222222');
+      expect(a.bucketKey).toBe(b.bucketKey);
+    });
+
+    it('PATCH and DELETE on the same message path differ only by method', () => {
+      const patch = new Route('PATCH',  '/channels/123/messages/111111111');
+      const del   = new Route('DELETE', '/channels/123/messages/111111111');
+      // same channel and normalized message ID, but different method → different key
+      expect(patch.bucketKey).not.toBe(del.bucketKey);
+    });
+
+    it('server-scoped and channel-scoped paths are always distinct keys', () => {
+      const server  = new Route('GET', '/servers/1/channels');
+      const channel = new Route('GET', '/channels/1/messages');
+      expect(server.bucketKey).not.toBe(channel.bucketKey);
+    });
+  });
+
+  describe('url()', () => {
+    it('appends path to the base URL', () => {
+      const r = new Route('GET', '/servers/123');
+      expect(r.url('https://api.intent.chat/v1')).toBe('https://api.intent.chat/v1/servers/123');
+    });
+
+    it('works with trailing-slash-free bases', () => {
+      const r = new Route('POST', '/channels/1/messages');
+      expect(r.url('https://api.intent.chat/v1')).toBe('https://api.intent.chat/v1/channels/1/messages');
+    });
+  });
+});

--- a/src/rest/errors.test.ts
+++ b/src/rest/errors.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  IntentError,
+  HTTPError,
+  RateLimitError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ServerError,
+} from './errors';
+
+describe('error classes', () => {
+  describe('IntentError', () => {
+    it('is an instance of Error', () => {
+      expect(new IntentError('oops')).toBeInstanceOf(Error);
+    });
+
+    it('sets name to IntentError', () => {
+      expect(new IntentError('oops').name).toBe('IntentError');
+    });
+
+    it('preserves the message', () => {
+      expect(new IntentError('something went wrong').message).toBe('something went wrong');
+    });
+  });
+
+  describe('HTTPError', () => {
+    const err = new HTTPError(422, 'POST', '/servers', 'Unprocessable', 'INVALID_BODY');
+
+    it('extends IntentError', () => {
+      expect(err).toBeInstanceOf(IntentError);
+    });
+
+    it('exposes status, method, url, and code', () => {
+      expect(err.status).toBe(422);
+      expect(err.method).toBe('POST');
+      expect(err.url).toBe('/servers');
+      expect(err.code).toBe('INVALID_BODY');
+    });
+
+    it('code is optional', () => {
+      const noCode = new HTTPError(400, 'GET', '/x', 'Bad request');
+      expect(noCode.code).toBeUndefined();
+    });
+  });
+
+  describe('RateLimitError', () => {
+    const err = new RateLimitError('GET', '/channels/1/messages', 5, true, 'bucket-abc');
+
+    it('extends HTTPError and IntentError', () => {
+      expect(err).toBeInstanceOf(HTTPError);
+      expect(err).toBeInstanceOf(IntentError);
+    });
+
+    it('always has status 429', () => {
+      expect(err.status).toBe(429);
+    });
+
+    it('exposes retryAfter, global flag, and bucket', () => {
+      expect(err.retryAfter).toBe(5);
+      expect(err.global).toBe(true);
+      expect(err.bucket).toBe('bucket-abc');
+    });
+
+    it('bucket is optional', () => {
+      const noBucket = new RateLimitError('GET', '/x', 1, false);
+      expect(noBucket.bucket).toBeUndefined();
+    });
+
+    it('global can be false for per-route limits', () => {
+      const perRoute = new RateLimitError('POST', '/servers', 2, false, 'srv-bucket');
+      expect(perRoute.global).toBe(false);
+    });
+  });
+
+  describe('UnauthorizedError', () => {
+    const err = new UnauthorizedError('GET', '/servers', 'invalid token');
+
+    it('extends HTTPError', () => {
+      expect(err).toBeInstanceOf(HTTPError);
+    });
+
+    it('status is 401', () => {
+      expect(err.status).toBe(401);
+    });
+
+    it('code is UNAUTHORIZED', () => {
+      expect(err.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  describe('ForbiddenError', () => {
+    const err = new ForbiddenError('DELETE', '/servers/1', 'missing permissions');
+
+    it('extends HTTPError', () => {
+      expect(err).toBeInstanceOf(HTTPError);
+    });
+
+    it('status is 403', () => {
+      expect(err.status).toBe(403);
+    });
+
+    it('code is FORBIDDEN', () => {
+      expect(err.code).toBe('FORBIDDEN');
+    });
+  });
+
+  describe('NotFoundError', () => {
+    const err = new NotFoundError('GET', '/servers/999', 'server not found');
+
+    it('extends HTTPError', () => {
+      expect(err).toBeInstanceOf(HTTPError);
+    });
+
+    it('status is 404', () => {
+      expect(err.status).toBe(404);
+    });
+
+    it('code is NOT_FOUND', () => {
+      expect(err.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('ServerError', () => {
+    it('extends HTTPError', () => {
+      expect(new ServerError(500, 'GET', '/x', 'internal error')).toBeInstanceOf(HTTPError);
+    });
+
+    it('accepts any 5xx status', () => {
+      expect(new ServerError(502, 'GET', '/x', 'bad gateway').status).toBe(502);
+      expect(new ServerError(503, 'GET', '/x', 'unavailable').status).toBe(503);
+      expect(new ServerError(504, 'GET', '/x', 'timeout').status).toBe(504);
+    });
+
+    it('code is SERVER_ERROR', () => {
+      expect(new ServerError(500, 'GET', '/x', 'oops').code).toBe('SERVER_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
Closes #6

The REST client had no real test coverage. This adds four new test files and expands the existing one to cover everything the issue asked for.

**Route bucket keys**

`Route.test.ts` is new. Verifies that major params (server ID, channel ID) produce separate rate limit buckets while minor params (message ID) get normalized so requests against different messages in the same channel share one.

**Error class hierarchy**

`errors.test.ts` is new. Every error class gets tested for the right inheritance chain and the fields specific to it. `RateLimitError` gets extra attention since `retryAfter`, `global`, and `bucket` are the whole point of that class existing.

**Request basics**

`REST.test.ts` now stubs `global.fetch` inside a scoped describe block to verify that REST actually sends the right method, URL, auth header, and body. The stub is cleaned up after each test so it doesn't affect the existing token guard tests.

**Error status mapping**

429, 401, 403, 404, 500, 502, and unknown 4xx each get a test asserting the right error type comes back. The 429 and 5xx tests use `maxRetries: 0` so they throw immediately rather than sleeping through retry delays and exhausting the fetch mock queue.

**Snowflake validation**

The original tests only covered `getServer`. This expands to `getChannel`, `createMessage`, `getMessage` (both IDs separately), and the `before`/`after` cursors on `listMessages`. Also adds a positive case confirming a valid numeric snowflake passes through to the network layer.